### PR TITLE
飯綱町で見かけたりんごを追加

### DIFF
--- a/packages/ringo-db/src/apples.ts
+++ b/packages/ringo-db/src/apples.ts
@@ -435,6 +435,30 @@ const appleSet: Set<Apple> = new Set([
     name: 'Prince',
     color: 'Brown',
   },
+  {
+    name: 'ニュージョナゴールド',
+    color: 'LightSalmon',
+  },
+  {
+    name: 'ローズパール',
+    color: 'Pink',
+  },
+  {
+    name: 'ベル・ド・ボスクープ',
+    color: 'OliveDrab',
+  },
+  {
+    name: 'エグレモント・ラセット',
+    color: 'Tan',
+  },
+  {
+    name: 'ブレンハイム・オレンジ',
+    color: 'DarkSeaGreen',
+  },
+  {
+    name: 'サマーランド',
+    color: 'LightCoral',
+  },
 ])
 
 export const apples = [...appleSet]


### PR DESCRIPTION
追加したりんご

・ニュージョナゴールド
・ローズパール
・ベル・ド・ボスクープ
・エグレモント・ラセット
・ブレンハイム・オレンジ
・サマーランド